### PR TITLE
Service compatible with JWT.io standard RFC 7519

### DIFF
--- a/models/JWTService.cfc
+++ b/models/JWTService.cfc
@@ -8,7 +8,13 @@ component singleton {
 			* HmacSHA512
 	*/
 
-	function decode( required string token, required string key , string algorithm = "HmacSHA512" ) {
+	variables.instance.algorithmMap = {
+		"HS256": "HmacSHA256",
+		"HS384": "HmacSHA384",
+		"HS512": "HmacSHA512"
+	};
+
+	function decode( required string token, required string key , string algorithm = "HS512" ) {
 	
 		if ( ListLen( arguments.token , "." ) != 3 ) {
 			throw( type="Invalid Token", message="Token should contain 3 segments" );
@@ -19,28 +25,28 @@ component singleton {
 		var signiture 	= ListGetAt( arguments.token , 3 , "." );
 
 		var signInput = ListGetAt( arguments.token , 1 , "." ) & "." & ListGetAt( arguments.token , 2 , "." );
-		if ( signiture != _sign( signInput , arguments.key , arguments.algorithm )) {
+		if ( signiture != _sign( signInput , arguments.key , variables.instance.algorithmMap[arguments.algorithm] )) {
 			throw( type="Invalid Token" , message="Signiture verification failed");
 		}
 
 		return payload;
 	}
 
-	function encode( required struct payload , required string key , string algorithm="HmacSHA512" ) {
+	function encode( required struct payload , required string key , string algorithm="HS512" ) {
 
 		var segments = "";
 
 		segments = ListAppend( segments , _base64UrlEscape( toBase64( serializeJSON( { "typ" =  "JWT", "alg" = arguments.algorithm } ))) , "." );
 		segments = ListAppend( segments , _base64UrlEscape( toBase64( serializeJSON( arguments.payload ))) , "." );
 		segments = ListAppend( segments , _sign( segments , arguments.key , arguments.algorithm ) , "." );
-
+		
 		return segments;
 	}
 
-	function verify( required string token, required string key , string algorithm="HmacSHA512" ) {
+	function verify( required string token, required string key , string algorithm="HS512" ) {
 		var isValid = true;
 		try {
-			decode( arguments.token, arguments.key , arguments.algorithm );
+			decode( arguments.token, arguments.key , variables.instance.algorithmMap[arguments.algorithm] );
 		}
 		catch(any e) {
 			isValid = false;
@@ -49,9 +55,9 @@ component singleton {
 		return isValid;
 	}
 
-	private function _sign( required string msg , required string key , algorithm="HmacSHA512" ) {
+	private function _sign( required string msg , required string key , string algorithm="HS512" ) {
 		var keySpec = CreateObject( "java" , "javax.crypto.spec.SecretKeySpec" ).init( arguments.key.getBytes() , arguments.algorithm );
-		var mac = CreateObject( "java" , "javax.crypto.Mac" ).getInstance( arguments.algorithm );
+		var mac = CreateObject( "java" , "javax.crypto.Mac" ).getInstance( variables.instance.algorithmMap[arguments.algorithm] );
 		mac.init( keySpec );
 		return _base64URLEscape( toBase64( mac.doFinal( msg.getBytes() )));
 	}


### PR DESCRIPTION
The JWT.io standard requires a header in the format of 

header = '{"alg":"HS256","typ":"JWT"}' 

I have added a lookup table so there is a compatible name 'HS526' and correct 'HmacSHA256' mac algorithm.

Supported Mac algorithms:
"HS256": "HmacSHA256",
"HS384": "HmacSHA384",
"HS512": "HmacSHA512"

